### PR TITLE
Fix isApiKeySet bug

### DIFF
--- a/lib/server/enclave.js
+++ b/lib/server/enclave.js
@@ -44,7 +44,7 @@ const init = function init () {
   }
 
   enclave.isApiKeySet = function isApiKeySet () {
-    return isApiKeySet;
+    return apiKeySet;
   }
 
   enclave.isApiKey = function isApiKey (keyValue) {


### PR DESCRIPTION
## Summary
- fix return value in `enclave.isApiKeySet`

## Testing
- `npm test` *(fails: env-cmd not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c82fd4a0832c9dbc73d228ad3f30